### PR TITLE
Make exposing the MongoDB port optional rather than the default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,13 @@ database:
   image: 'tutum/mongodb:latest'
   environment:
     - MONGODB_PASS={{** CHANGE ME **}}
-  ports:
-    - '27017:27017'
+
+# Uncomment if you want to expose the MongoDB port directly
+# If you're using the API interface (highly recommended) then you can 
+# safely leave this commented out 
+#  ports:
+#    - '27017:27017'
+
 nightscout:
   image: 'nightscout/cgm-remote-monitor-development:latest'
   environment:


### PR DESCRIPTION
As the API is probably the best interface moving forward, I think it would be best not to expose the MongoDB port by default. I've simply commented out exposing the port with a quick comment. This doesn't affect the Nightscout container itself as it's linked but would limit any accidental exposure.

Just my thoughts anyway, thanks for the work so far with the Docker images!
