### PR TITLE
run bower explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /opt/app
 RUN git clone git://github.com/nightscout/cgm-remote-monitor.git /opt/app
 RUN cd /opt/app &&  git checkout ${DEPLOY_HEAD-master}
 RUN cd /opt/app && npm install
+RUN cd /opt/app && node node_modules/bower/bin/bower --allow-root install --config.interactive=false
 RUN cd /opt/app && npm run env
 EXPOSE 5000
 EXPOSE 8080


### PR DESCRIPTION
Hi, I'm hacking my way into Docker and nodejs.
Without the proposed bower RUN in Dockerfile, the nightscout portal is partially loading(the graph section is not rendered)
