### PR TITLE
Fix npm postinstall

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /opt/app
 RUN git clone git://github.com/nightscout/cgm-remote-monitor.git /opt/app
 RUN cd /opt/app &&  git checkout ${DEPLOY_HEAD-master}
 RUN cd /opt/app && npm install
+RUN cd /opt/app && npm run postinstall
 RUN cd /opt/app && npm run env
 EXPOSE 5000
 EXPOSE 8080


### PR DESCRIPTION
After building the project:

```
$ docker run --rm cgm-remote-monitor ls /opt/app/static
admin
api-docs.html
audio
browserconfig.xml
clock.html
css
glyphs
images
index.html
js
manifest.json
profile
report
robots.txt
```

Notice how `bower_components` is missing after the build. This (obviously) breaks the web UI. Running the `postinstall` task manually fixes this. I remember having this same issue with Docker & these older npm versions before.
