### PR TITLE
Use well-maintained images and official repo instead of outdated stuff

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,31 @@
-broker:
-  image: 'prologic/mosquitto:latest'
-  ports:
-    - '1883:1883'
-database:
-  image: 'tutum/mongodb:latest'
-  environment:
-    - MONGODB_PASS={{** CHANGE ME **}}
+version: "3"
+services:
+  broker:
+    image: 'eclipse-mosquitto'
+    ports:
+      - '1883:1883'
+  database:
+    image: 'mongo'
+    environment:
+      - 'MONGO_INITDB_ROOT_USERNAME=admin'
+      - 'MONGO_INITDB_ROOT_PASSWORD=CHANGEME'
+    ## Uncomment the ports section below to grant direct access to MongoDB
+    ## Before 2014 this was the common way to upload data to NightScout
+    ## In Summer 2014 it was deprecated in favor of the new REST API
+    # ports:
+    #  - '27017:27017'
 
-# Uncomment if you want to expose the MongoDB port directly
-# If you're using the API interface (highly recommended) then you can 
-# safely leave this commented out 
-#  ports:
-#    - '27017:27017'
-
-nightscout:
-  image: 'nightscout/cgm-remote-monitor-development:latest'
-  environment:
-    - API_SECRET={{** CHANGE ME **}}
-    - 'MONGO_CONNECTION=mongodb://admin:{{** CHANGE ME **}}@database/admin'
-    - 'MQTT_MONITOR=mqtt://{{** CHANGE ME **}}@broker'
-    - PORT=1337
-  links:
-    - broker
-    - database
-  ports:
-    - '1337:1337'
+  nightscout:
+    build:
+      context: https://github.com/nightscout/cgm-remote-monitor.git
+      dockerfile: Dockerfile.example
+    environment:
+      - 'API_SECRET=CHANGEME_PLEASE'
+      - 'MONGO_CONNECTION=mongodb://admin:CHANGEME@database/admin'
+      - 'MQTT_MONITOR=mqtt://CHANGEME@broker'
+      - 'PORT=1337'
+    links:
+      - broker
+      - database
+    ports:
+      - '1337:1337'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - 'MONGO_CONNECTION=mongodb://admin:CHANGEME@database/admin'
       - 'MQTT_MONITOR=mqtt://CHANGEME@broker'
       - 'PORT=1337'
-    links:
+    depends_on:
       - broker
       - database
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   nightscout:
     build:
       context: https://github.com/nightscout/cgm-remote-monitor.git
-      dockerfile: Dockerfile.example
+      dockerfile: Dockerfile
     environment:
       - 'API_SECRET=CHANGEME_PLEASE'
       - 'MONGO_CONNECTION=mongodb://admin:CHANGEME@database/admin'


### PR DESCRIPTION
I've changed the docker-compose file to use better maintained versions of the upstream dependencies and directly build the Nightscout NodeJS app instead of relying on an unmaintained fork.

Let's start with the dependencies:
1. I replaced the prologic Mosquitto build with the official Mosquitto build from the Eclipse Foundation.
    This might not be so important as the only known security problem in Mosquitto was an authentication bypass, but no authentication is used in this setup anyways.

2. MongoDB by tutum was replaced by the official docker-community maintained version called mongo, which is also sponsored by Mongo Inc. (The developers of MongoDB)
    The old MongoDB had several CVE security issues. Most of them can only be used in DoS attacks, but there were also 2 overflow errors which can potentially be used for reading sensitive information or modify memory.

3. Last but not least the main dish:
    The compose file in this repo uses a prebuilt docker image for the nightscout NodeJS application that is based on a third party fork by user Fokko.
    Said fork hasn't been updated in 2.5 years and is currently behind the master branch by about 1300 commits.
    Why would anyone use a docker image explicitly marked for dev purposes only and use a verison that's outdated by 2.5 years?

So this PR updates the docker-compose.yml file to bring things into the year 2018.
I've changed the compose file to version 3 syntax (available in Docker 1.13.0 from January 2017 and newer) in order to use the build from external repositories feature instead of relying on a prebuilt docker-image for the main app.
The dependencies have been updated to use the official versions of the apps:
Mosquitto is now using the official _eclipse-mosquitto_ image from the Eclipse foundation and should receive timely updates.
Same is true for the MongoDB version, which was replaced with the official _mongo_ image.

I've also modified the comment inside this file about exposing the MongoDB port a bit, so that others who aren't that involved with development know when this is actually needed and that it's usually not neccessary in 2018 anymore.

Hope others can profit from this as well.
I didn't touch any of the cloud deployment guides as I never tried to deploy docker containers on servers not managed by myself or my company.